### PR TITLE
Replace all unwrap with better error handling

### DIFF
--- a/src/devices/serials/ns16550.rs
+++ b/src/devices/serials/ns16550.rs
@@ -62,7 +62,8 @@ impl Ns16550 {
         let size_cells_val: u32 =
             u32::from_be(unsafe { ptr::read(size_cells.off_value as *const u32) });
         // Get device memory region
-        let reg = get_node_prop(node, "reg").expect("ERROR: ns16550 node is missing '#address-cells' property");
+        let reg =
+            get_node_prop(node, "reg").expect("ERROR: ns16550 node is missing 'reg' property");
         let mut reg_buff: ArrayVec<u32, 120> = ArrayVec::new();
         let mut reg_cursor = reg.off_value;
         // Divide reg.value_len by 4 because we read u32 and not u8
@@ -99,6 +100,7 @@ impl Ns16550 {
         let devices = unsafe { &mut *UART_DEVICES.get() };
 
         let len = devices.len();
+        #[allow(clippy::needless_range_loop)]
         for i in 0..len {
             if devices[i].is_none() {
                 devices[i] = Some(UartDevice {

--- a/src/dtb/helpers.rs
+++ b/src/dtb/helpers.rs
@@ -16,6 +16,7 @@ pub fn get_fdt_node(index: usize) -> FdtNode {
 
 /// Return the index of the given node in the NODE_POOL
 pub fn get_index_fdt_node(node: &FdtNode) -> usize {
+    #[allow(clippy::needless_range_loop)]
     for i in 0..unsafe { NODE_COUNT } {
         let current = unsafe { NODE_POOL[i] };
         if current.first_prop_off == node.first_prop_off {
@@ -54,7 +55,7 @@ pub fn get_node_prop(node: &FdtNode, prop_name: &str) -> Option<Property> {
             }
         }
         let prop_name_str = str::from_utf8(&prop_name_buff)
-            .unwrap()
+            .expect("Failed to cast &[u8] to &str. Invalid UTF-8 char in FDT property")
             .trim_end_matches('\0');
         // Check prop name with wanted prop_name
         if prop_name_str == prop_name {
@@ -93,7 +94,7 @@ pub fn get_node_prop_in_hierarchy(node: &FdtNode, prop_name: &str) -> Option<Pro
                 }
             }
             let prop_name_str = str::from_utf8(&prop_name_buff)
-                .unwrap()
+                .expect("Failed to cast &[u8] to &str. Invalid UTF-8 char in FDT property")
                 .trim_end_matches('\0');
             // Check prop name with wanted prop_name
             if prop_name_str == prop_name {
@@ -102,7 +103,9 @@ pub fn get_node_prop_in_hierarchy(node: &FdtNode, prop_name: &str) -> Option<Pro
         }
         // If reaching this point, it means that the wanted prop was not found in current node, so
         // update the search_node to be the parent one
-        current_search_node = search_node.parent_node_index.unwrap();
+        current_search_node = search_node
+            .parent_node_index
+            .expect("Failed to get the FDT parent node");
     }
     None
 }

--- a/src/dtb/mod.rs
+++ b/src/dtb/mod.rs
@@ -192,7 +192,9 @@ fn parse_fdt_struct(dt_struct_addr: usize, string_block_off: usize) {
             // Pop top of the node stack or continue if stack empty
             let node = {
                 if !node_stack.is_empty() {
-                    node_stack.pop().unwrap()
+                    node_stack
+                        .pop()
+                        .expect("Failed to pop the top of FDT node stack")
                 } else {
                     continue;
                 }

--- a/src/print.rs
+++ b/src/print.rs
@@ -4,7 +4,7 @@ use crate::devices::serials::{KCONSOLE, UART_DEVICES};
 pub fn print(arg: core::fmt::Arguments) {
     let devices = unsafe { &mut *UART_DEVICES.get() };
     if let Some(uart) = &mut devices[0] {
-        uart.driver.write_fmt(arg).unwrap();
+        let _ = uart.driver.write_fmt(arg);
     }
 }
 


### PR DESCRIPTION
This pull request focuses on improving error handling and code robustness across several device initialization and FDT (Flattened Device Tree) helper functions. The main changes involve replacing `unwrap()` calls with explicit error messages using `expect()`, which provides clearer diagnostics in case of failure. Additionally, some minor code style improvements and lint suppressions have been introduced for better code quality.

### Error handling improvements

* Replaced all `unwrap()` calls with `expect()` and descriptive error messages in device initialization routines and FDT property accessors, improving diagnostics and preventing silent panics. (`src/devices/mod.rs`, `src/devices/serials/ns16550.rs`, `src/dtb/helpers.rs`, `src/dtb/mod.rs`) [[1]](diffhunk://#diff-6a66baba195bea8f1cb355ddc94c14a726f1d00481dcbd6ef91c3946ca92a4afL48-R48) [[2]](diffhunk://#diff-6a66baba195bea8f1cb355ddc94c14a726f1d00481dcbd6ef91c3946ca92a4afL67-R72) [[3]](diffhunk://#diff-ed2d3a35b61f370d4212f85397fffe354998dfd7935e5640d4bfc8bb69c76bb8L55-R66) [[4]](diffhunk://#diff-d0c9abf72a76500769508c5bd66f098014c555ae0fd6482fd5e0707c5e4ab2ecL57-R58) [[5]](diffhunk://#diff-d0c9abf72a76500769508c5bd66f098014c555ae0fd6482fd5e0707c5e4ab2ecL96-R97) [[6]](diffhunk://#diff-d0c9abf72a76500769508c5bd66f098014c555ae0fd6482fd5e0707c5e4ab2ecL105-R108) [[7]](diffhunk://#diff-187e826dbf1879a8b85d6fe33de1ec7c473ae372c4036e2d8346c4018add6ef0L195-R197)

### Code style and linting

* Added `#[allow(clippy::needless_range_loop)]` annotations to suppress Clippy lint warnings in loops where the range loop is intentional. (`src/devices/serials/ns16550.rs`, `src/dtb/helpers.rs`) [[1]](diffhunk://#diff-ed2d3a35b61f370d4212f85397fffe354998dfd7935e5640d4bfc8bb69c76bb8R103) [[2]](diffhunk://#diff-d0c9abf72a76500769508c5bd66f098014c555ae0fd6482fd5e0707c5e4ab2ecR19)

### Minor robustness improvements

* Changed error handling in `print()` to ignore formatting errors instead of panicking, making printing more robust. (`src/print.rs`)

These changes collectively make the codebase safer and easier to debug by surfacing meaningful error messages and preventing unexpected panics.