### PR TITLE
feat(devices): add new fn to DriverRegion struct impl and refactor ns…

### DIFF
--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -5,7 +5,7 @@ use serials::ns16550::Ns16550;
 
 use crate::dtb::{
     FdtNode,
-    helpers::{fdt_get_all_nodes, fdt_get_node_prop},
+    helpers::{fdt_get_all_nodes, fdt_get_node_prop, fdt_get_node_prop_in_hierarchy},
 };
 
 /// Module for serials devices
@@ -36,6 +36,53 @@ struct Driver<'a> {
 pub struct DriverRegion {
     pub addr: usize,
     pub size: usize,
+}
+
+impl DriverRegion {
+    pub fn new(node: &FdtNode) -> Self {
+        // Get address and size cells
+        let address_cells = fdt_get_node_prop_in_hierarchy(node, "#address-cells")
+            .expect("ERROR: node is missing '#address-cells' property from parent bus\n");
+        let size_cells = fdt_get_node_prop_in_hierarchy(node, "#size-cells")
+            .expect("ERROR: node is missing '#size-cells' property from parent bus\n");
+        // Ptr read address and size cells value from off and cast it to u32 target's endianness
+        let address_cells_val: u32 =
+            u32::from_be(unsafe { ptr::read(address_cells.off_value as *const u32) });
+        let size_cells_val: u32 =
+            u32::from_be(unsafe { ptr::read(size_cells.off_value as *const u32) });
+        // Get device memory region
+        let reg = fdt_get_node_prop(node, "reg").expect("ERROR: node is missing 'reg' property");
+        let mut reg_buff: ArrayVec<u32, 120> = ArrayVec::new();
+        let mut reg_cursor = reg.off_value;
+        // Divide reg.value_len by 4 because we read u32 and not u8
+        for _ in 0..reg.value_len / 4 {
+            let value = u32::from_be(unsafe { ptr::read(reg_cursor as *const u32) });
+            reg_buff.push(value);
+            reg_cursor += 4;
+        }
+        // Region size from #address-cells and #size-cells properties value
+        let reg_size = address_cells_val + size_cells_val;
+        // Init a new DriverRegion
+        let mut device_addr: DriverRegion = DriverRegion { addr: 0, size: 0 };
+        for addr in reg_buff.chunks(reg_size as usize) {
+            // Build addr from chunk
+            let mut device_addr_build: u64 = 0;
+            for i in 0..address_cells_val {
+                device_addr_build = (device_addr_build << 32) | (addr[i as usize] as u64);
+            }
+            // Build size from chunk
+            let mut device_size: u64 = 0;
+            for i in 0..size_cells_val {
+                device_size =
+                    (device_size << 32) | (addr[address_cells_val as usize + i as usize] as u64);
+            }
+            device_addr = DriverRegion {
+                addr: device_addr_build as usize,
+                size: device_size as usize,
+            }
+        }
+        device_addr
+    }
 }
 
 /// Static driver match table to save all handled drivers in the kernel. Point to the init function used to init

--- a/src/devices/serials/ns16550.rs
+++ b/src/devices/serials/ns16550.rs
@@ -1,16 +1,8 @@
-use core::{
-    fmt::{self, Write},
-    ptr,
-};
-
-use arrayvec::ArrayVec;
+use core::fmt::{self, Write};
 
 use crate::{
     devices::{DriverRegion, serials::SERIAL_DEVICES},
-    dtb::{
-        FdtNode,
-        helpers::{fdt_get_node_prop, fdt_get_node_prop_in_hierarchy},
-    },
+    dtb::FdtNode,
 };
 
 use super::{UartDevice, UartDriver};
@@ -52,48 +44,7 @@ static mut NS16550_INSTANCE: Ns16550 = Ns16550 {
 impl Ns16550 {
     /// Init a new Ns16550 from the given fdt node
     pub fn init(node: &FdtNode) {
-        // Get address and size cells
-        let address_cells = fdt_get_node_prop_in_hierarchy(node, "#address-cells")
-            .expect("ERROR: ns16550 node is missing '#address-cells' property from parent bus\n");
-        let size_cells = fdt_get_node_prop_in_hierarchy(node, "#size-cells")
-            .expect("ERROR: ns16550 node is missing '#size-cells' property from parent bus\n");
-        // Ptr read address and size cells value from off and cast it to u32 target's endianness
-        let address_cells_val: u32 =
-            u32::from_be(unsafe { ptr::read(address_cells.off_value as *const u32) });
-        let size_cells_val: u32 =
-            u32::from_be(unsafe { ptr::read(size_cells.off_value as *const u32) });
-        // Get device memory region
-        let reg =
-            fdt_get_node_prop(node, "reg").expect("ERROR: ns16550 node is missing 'reg' property");
-        let mut reg_buff: ArrayVec<u32, 120> = ArrayVec::new();
-        let mut reg_cursor = reg.off_value;
-        // Divide reg.value_len by 4 because we read u32 and not u8
-        for _ in 0..reg.value_len / 4 {
-            let value = u32::from_be(unsafe { ptr::read(reg_cursor as *const u32) });
-            reg_buff.push(value);
-            reg_cursor += 4;
-        }
-        // Region size from #address-cells and #size-cells properties value
-        let reg_size = address_cells_val + size_cells_val;
-        // Init a new DriverRegion
-        let mut device_addr: DriverRegion = DriverRegion { addr: 0, size: 0 };
-        for addr in reg_buff.chunks(reg_size as usize) {
-            // Build addr from chunk
-            let mut device_addr_build: u64 = 0;
-            for i in 0..address_cells_val {
-                device_addr_build = (device_addr_build << 32) | (addr[i as usize] as u64);
-            }
-            // Build size from chunk
-            let mut device_size: u64 = 0;
-            for i in 0..size_cells_val {
-                device_size =
-                    (device_size << 32) | (addr[address_cells_val as usize + i as usize] as u64);
-            }
-            device_addr = DriverRegion {
-                addr: device_addr_build as usize,
-                size: device_size as usize,
-            }
-        }
+        let device_addr: DriverRegion = DriverRegion::new(node);
         let ns16550: Ns16550 = Ns16550 {
             region: device_addr,
         };

--- a/src/devices/timer/clint0.rs
+++ b/src/devices/timer/clint0.rs
@@ -9,10 +9,7 @@ use crate::{
     },
     dtb::{
         FdtNode,
-        helpers::{
-            fdt_get_node, fdt_get_node_by_phandle, fdt_get_node_prop,
-            fdt_get_node_prop_in_hierarchy,
-        },
+        helpers::{fdt_get_node, fdt_get_node_by_phandle, fdt_get_node_prop},
     },
 };
 
@@ -45,48 +42,7 @@ pub static mut CLINT_DEVICE: Clint0 = Clint0 {
 
 impl Clint0 {
     pub fn init(node: &FdtNode) {
-        // Get address and size cells
-        let address_cells = fdt_get_node_prop_in_hierarchy(node, "#address-cells")
-            .expect("ERROR: clint0 node is missing '#address-cells' property from parent bus\n");
-        let size_cells = fdt_get_node_prop_in_hierarchy(node, "#size-cells")
-            .expect("ERROR: clint0 node is missing '#size-cells' property from parent bus\n");
-        // Ptr read address and size cells value from off and cast it to u32 target's endianness
-        let address_cells_val: u32 =
-            u32::from_be(unsafe { ptr::read(address_cells.off_value as *const u32) });
-        let size_cells_val: u32 =
-            u32::from_be(unsafe { ptr::read(size_cells.off_value as *const u32) });
-        // Get device memory region
-        let reg =
-            fdt_get_node_prop(node, "reg").expect("ERROR: clint0 node is missing 'reg' property");
-        let mut reg_buff: ArrayVec<u32, 120> = ArrayVec::new();
-        let mut reg_cursor = reg.off_value;
-        // Divide reg.value_len by 4 because we read u32 and not u8
-        for _ in 0..reg.value_len / 4 {
-            let value = u32::from_be(unsafe { ptr::read(reg_cursor as *const u32) });
-            reg_buff.push(value);
-            reg_cursor += 4;
-        }
-        // Region size from #address-cells and #size-cells properties value
-        let reg_size = address_cells_val + size_cells_val;
-        // Init a new DriverRegion
-        let mut device_addr: DriverRegion = DriverRegion { addr: 0, size: 0 };
-        for addr in reg_buff.chunks(reg_size as usize) {
-            // Build addr from chunk
-            let mut device_addr_build: u64 = 0;
-            for i in 0..address_cells_val {
-                device_addr_build = (device_addr_build << 32) | (addr[i as usize] as u64);
-            }
-            // Build size from chunk
-            let mut device_size: u64 = 0;
-            for i in 0..size_cells_val {
-                device_size =
-                    (device_size << 32) | (addr[address_cells_val as usize + i as usize] as u64);
-            }
-            device_addr = DriverRegion {
-                addr: device_addr_build as usize,
-                size: device_size as usize,
-            }
-        }
+        let device_addr: DriverRegion = DriverRegion::new(node);
         let interrupt: Interrupt = Interrupt {
             cpu_intc: null_mut(),
             irq_len: 0,


### PR DESCRIPTION
This pull request refactors how device memory regions are parsed and initialized from device tree nodes by introducing a new constructor method for the `DriverRegion` struct. The main goal is to centralize and deduplicate the logic for extracting address and size information from device tree nodes, which improves maintainability and reduces code repetition across device drivers.

Key changes include:

### Refactoring and Code Deduplication

* Introduced a new `DriverRegion::new(&FdtNode)` constructor that encapsulates the logic for extracting address and size cells, parsing the `reg` property, and building the memory region from device tree nodes. This moves previously duplicated logic from individual device drivers into a single place.

* Updated the `Ns16550` serial driver and the `Clint0` timer driver to use the new `DriverRegion::new` method, replacing their local implementations for parsing device memory regions. This results in cleaner and more maintainable driver initialization code. [[1]](diffhunk://#diff-ed2d3a35b61f370d4212f85397fffe354998dfd7935e5640d4bfc8bb69c76bb8L55-R47) [[2]](diffhunk://#diff-3a13f18fee84f2f3402ac08b388f773624c709001b545e281846c3eddcc8ca92L48-R45)

### Imports and Cleanup

* Updated imports in `src/devices/mod.rs`, `src/devices/serials/ns16550.rs`, and `src/devices/timer/clint0.rs` to reflect the new usage of `DriverRegion::new` and to remove now-unnecessary dependencies on device tree helper functions. [[1]](diffhunk://#diff-6a66baba195bea8f1cb355ddc94c14a726f1d00481dcbd6ef91c3946ca92a4afL8-R8) [[2]](diffhunk://#diff-ed2d3a35b61f370d4212f85397fffe354998dfd7935e5640d4bfc8bb69c76bb8L1-R5) [[3]](diffhunk://#diff-3a13f18fee84f2f3402ac08b388f773624c709001b545e281846c3eddcc8ca92L12-R12)…16550 and clint0 init fn to avoid code duplication