### PR TITLE
Replace ptr::read with read_volatile on clint0 drivers

### DIFF
--- a/src/devices/timer/clint0.rs
+++ b/src/devices/timer/clint0.rs
@@ -147,9 +147,9 @@ impl Clint0 {
         while mtime_high != mtime_high_check {
             let mtime_low_addr = self.region.addr + off;
             let mtime_high_addr = self.region.addr + off + 4;
-            mtime_high = unsafe { ptr::read(mtime_high_addr as *const u32) };
-            mtime_low = unsafe { ptr::read(mtime_low_addr as *const u32) };
-            mtime_high_check = unsafe { ptr::read(mtime_high_addr as *const u32) };
+            mtime_high = unsafe { ptr::read_volatile(mtime_high_addr as *const u32) };
+            mtime_low = unsafe { ptr::read_volatile(mtime_low_addr as *const u32) };
+            mtime_high_check = unsafe { ptr::read_volatile(mtime_high_addr as *const u32) };
         }
         // Bitwise to compute mtime from value. Cannot read u64 directly on riscv 32 bits.
         let output: u64 = ((mtime_high as u64) << 32) | (mtime_low as u64);


### PR DESCRIPTION
This pull request updates the way timer register values are read in the `Clint0` implementation to ensure correct behavior when interacting with hardware. The main change is replacing standard pointer reads with volatile reads, which is important for memory-mapped I/O where the value can change outside the program's control.

**Hardware interaction improvements:**

* Changed all `ptr::read` calls to `ptr::read_volatile` when reading the `mtime_high` and `mtime_low` timer registers in `src/devices/timer/clint0.rs` to ensure proper handling of hardware register accesses.…on optimisation