### PR TITLE
Write test framework documentation

### DIFF
--- a/Documentation/kernel/test_framework.md
+++ b/Documentation/kernel/test_framework.md
@@ -98,6 +98,6 @@ A test can have 3 different conclusion:
 - Kernel integrity failure, if the test encounter a critical failure, like a device not correctly initialized. This failure indicate that the state after the fail could lead to an unstable kernel. That shouldn't happened, so panic directly.
 
 ## Invariants
-• All test suites must be registered before test execution starts.
-• Test suites are static and must remain valid for the entire test runtime.
-• Test code must not rely on subsystems that are not initialized in test mode.
+- All test suites must be registered before test execution starts.
+- Test suites are static and must remain valid for the entire test runtime.
+- Test code must not rely on subsystems that are not initialized in test mode.


### PR DESCRIPTION
This pull request adds comprehensive documentation for the kernel test framework. The new documentation explains the motivation, structure, and usage of the custom kernel test framework, making it easier for developers to understand how to write and organize tests for kernel components.

Documentation improvements:

* Added a new file, `Documentation/kernel/test_framework.md`, detailing the purpose, design, and usage of the kernel test framework, including example code and conventions for writing test suites and cases.
* Included a table of contents and sections covering test behaviors and invariants to clarify expected outcomes and requirements for kernel testing.