### PR TITLE
Add info module and static kernel version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "lrnrtos"
-version = "0.3.2"
+version = "0.3.5"
 dependencies = [
  "arrayvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lrnrtos"
-version = "0.3.2"
+version = "0.3.5"
 edition = "2024"
 
 [[bin]]

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -2,6 +2,7 @@ use crate::{
     arch::traps::{enable_interrupts, trap_frame::init_trap_frame},
     config::TICK_SAFETY_DURATION,
     drivers::{cpufreq::CpuFreq, init_subsystems},
+    info::KERNEL_VERSION,
     kprint, kprint_fmt,
     ktime::set_ktime_seconds,
     log,
@@ -12,6 +13,7 @@ use crate::{
 
 #[unsafe(no_mangle)]
 pub fn kernel_early_boot(core: usize, dtb_addr: usize) -> ! {
+    kprint_fmt!("Kernel version: {}\n", KERNEL_VERSION);
     kprint_fmt!("Start kernel booting on CPU Core: {}.\n", core);
     kprint!("Initializing platform...\n");
     platform_init(dtb_addr);

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,0 +1,4 @@
+// The kernel exposes build-time version information at runtime.
+// This information is immutable and reflects the exact binary currently running.
+// It is intended for debugging, logging, and diagnostic purposes.
+pub static KERNEL_VERSION: &str = "0.3.5";

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,9 @@ pub mod misc;
 // Early boot module
 pub mod boot;
 
+// Kernel information
+pub mod info;
+
 // Test module
 #[cfg(feature = "test")]
 pub mod tests;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -10,7 +10,7 @@ mod suites;
 use platform::test_platform_init;
 use suites::test_suites;
 
-use crate::{kprint, kprint_fmt};
+use crate::{info::KERNEL_VERSION, kprint, kprint_fmt};
 
 #[macro_export]
 macro_rules! test_kprint {
@@ -234,6 +234,10 @@ pub fn test_runner(core: usize, dtb_addr: usize) -> ! {
         test_suites_nb,
         test_suites_failed,
         test_suites_skipped
+    );
+    kprint_fmt!(
+        "Kernel test mode using kernel version: {}\n",
+        KERNEL_VERSION,
     );
     // Exit Qemu at the end of the tests
     unsafe { ptr::write_volatile(0x100000 as *mut u32, 0x5555) };


### PR DESCRIPTION
This pull request adds runtime exposure of the kernel version for improved diagnostics and logging. The version is now accessible within the kernel and test modules, and is printed during early boot and test runs. The changes are grouped into kernel versioning and code organization.

**Kernel versioning and diagnostics:**
* Added a new static `KERNEL_VERSION` in `src/info.rs` to expose the build-time kernel version at runtime.
* Printed the kernel version during early boot in `kernel_early_boot` in `src/boot.rs`.
* Printed the kernel version in kernel test mode within `test_runner` in `src/tests/mod.rs`.

**Code organization:**
* Introduced a new `info` module in `src/main.rs` to encapsulate kernel information.
* Updated imports in `src/boot.rs` and `src/tests/mod.rs` to use the new `KERNEL_VERSION` constant. [[1]](diffhunk://#diff-d912ff9d8ba1a195bf14282d38de1732d78a6cafdb35140bd3510edf01ccc8bfR5) [[2]](diffhunk://#diff-35dd501674c29ffd5ce530e622a8726a658242d3a7fc15c623ad653985ccef46L13-R13)

**Version update:**
* Bumped the crate version in `Cargo.toml` from `0.3.2` to `0.3.5` to reflect these changes in early boot and in test flow, also bump kernel version to 0.3.5