### PR TITLE
Fix trap frame stack pointer and improve AlignedStack primitive

### DIFF
--- a/src/arch/riscv32/scheduler/mod.rs
+++ b/src/arch/riscv32/scheduler/mod.rs
@@ -1,4 +1,4 @@
-use crate::primitives::stack::AlignedStack;
+use crate::primitives::stack::AlignedStack16;
 
 #[repr(C)]
 pub struct SchedulerCtx {
@@ -10,7 +10,7 @@ pub struct SchedulerCtx {
     sp: *mut u8, // Offset 132
 }
 
-pub static mut SCHEDULER_STACK: AlignedStack<4098> = AlignedStack::new();
+pub static mut SCHEDULER_STACK: AlignedStack16<4098> = AlignedStack16::new();
 pub static mut SCHEDULER_CTX: SchedulerCtx = unsafe { core::mem::zeroed() };
 
 impl SchedulerCtx {

--- a/src/arch/riscv32/traps/trap_frame.rs
+++ b/src/arch/riscv32/traps/trap_frame.rs
@@ -18,6 +18,8 @@ Tests files:
 
 use core::{mem, ptr::null_mut};
 
+use crate::primitives::stack::AlignedStack16;
+
 #[repr(C)]
 // Trap frame structure, used to store all global registers, give a stack for the trap handling
 // to avoid using the kernel stack.
@@ -45,7 +47,7 @@ impl TrapFrame {
 }
 
 // Static buffer used as a stack for trap handling
-pub static mut TRAP_STACK_BUFF: [u8; 1024] = [0u8; 1024];
+pub static mut TRAP_STACK_BUFF: AlignedStack16<1024> = AlignedStack16::new();
 
 // Init TrapFrame with 0 in mem
 pub static mut KERNEL_TRAP_FRAME: TrapFrame = unsafe { mem::zeroed() };
@@ -55,6 +57,6 @@ pub fn init_trap_frame() {
     // Static mut safe because it's only used in kernel boot
     #[allow(static_mut_refs)]
     unsafe {
-        KERNEL_TRAP_FRAME.trap_stack = TRAP_STACK_BUFF.as_mut_ptr()
+        KERNEL_TRAP_FRAME.trap_stack = TRAP_STACK_BUFF.buf.as_mut_ptr().wrapping_add(1024);
     }
 }

--- a/src/primitives/stack.rs
+++ b/src/primitives/stack.rs
@@ -14,14 +14,15 @@ Tests files:
 References:
 */
 
-pub struct AlignedStack<const N: usize> {
+#[repr(align(16))]
+pub struct AlignedStack16<const N: usize> {
     pub buf: [u8; N],
 }
 
-impl<const N: usize> AlignedStack<N> {
+impl<const N: usize> AlignedStack16<N> {
     // Don't bother with this warning
     #[allow(clippy::new_without_default)]
     pub const fn new() -> Self {
-        AlignedStack { buf: [0u8; N] }
+        AlignedStack16 { buf: [0u8; N] }
     }
 }

--- a/src/tests/arch/riscv32/traps/trap_frame.rs
+++ b/src/tests/arch/riscv32/traps/trap_frame.rs
@@ -38,7 +38,9 @@ pub fn test_trap_frame_init() -> u8 {
     init_trap_frame();
     // Ok because test env, no concurrency
     #[allow(static_mut_refs)]
-    if unsafe { KERNEL_TRAP_FRAME.trap_stack } != unsafe { TRAP_STACK_BUFF.as_mut_ptr() } {
+    if unsafe { KERNEL_TRAP_FRAME.trap_stack }
+        != unsafe { TRAP_STACK_BUFF.buf.as_mut_ptr().wrapping_add(1024) }
+    {
         panic!("Trap frame trap_stack field should be initialized with ptr to TRAP_STACK_BUFF");
     }
     0


### PR DESCRIPTION
This pull request refactors the stack buffer types used in the RISC-V32 scheduler and trap handling code to ensure 16-byte alignment. The main change is the introduction and use of a new `AlignedStack16` type, replacing the previous `AlignedStack`, to guarantee proper stack alignment for architecture requirements.

Stack alignment improvements:

* Introduced the `AlignedStack16` struct in `src/primitives/stack.rs`, marked with `#[repr(align(16))]` to ensure 16-byte alignment, and updated its implementation accordingly.
* Replaced all usages of `AlignedStack` with `AlignedStack16` in the scheduler (`src/arch/riscv32/scheduler/mod.rs`) and trap handling code (`src/arch/riscv32/traps/trap_frame.rs`), including the static scheduler and trap stack buffers. [[1]](diffhunk://#diff-5f9edd481d4ea932fda0b1ace1936da777abcc9e8e1f9e1edde04652a250a1c0L1-R1) [[2]](diffhunk://#diff-5f9edd481d4ea932fda0b1ace1936da777abcc9e8e1f9e1edde04652a250a1c0L13-R13) [[3]](diffhunk://#diff-f46bc63f8262caeb6410524641befc9430f4b864b3495ae3a517a7b265db36e2R21-R22) [[4]](diffhunk://#diff-f46bc63f8262caeb6410524641befc9430f4b864b3495ae3a517a7b265db36e2L48-R50)

Trap stack initialization update:

* Updated trap stack pointer initialization to use the aligned buffer and point to the top of the stack, ensuring correct stack growth direction and alignment.

Test updates:

* Adjusted the trap frame initialization test to compare against the new pointer calculation using the aligned buffer.