### PR TITLE
Refactor update_kernel_sp function

### DIFF
--- a/src/arch/riscv32/mem.rs
+++ b/src/arch/riscv32/mem.rs
@@ -1,0 +1,6 @@
+use super::asm;
+
+pub fn update_kernel_sp(sp: usize) {
+    unsafe { core::arch::asm!("mv a0, {}", in(reg) sp) };
+    unsafe { asm::set_kernel_sp() };
+}

--- a/src/arch/riscv32/mod.rs
+++ b/src/arch/riscv32/mod.rs
@@ -1,4 +1,5 @@
 pub mod asm;
+pub mod mem;
 pub mod scheduler;
 pub mod start;
 pub mod task;

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -7,7 +7,7 @@ use crate::{
     ktime::set_ktime_seconds,
     log,
     logs::LogLevel,
-    mem::{memory_init, update_kernel_sp},
+    mem::{mem_update_kernel_sp, memory_init},
     platform::platform_init,
 };
 
@@ -34,7 +34,7 @@ pub fn kernel_early_boot(core: usize, dtb_addr: usize) -> ! {
     );
     memory_init();
     log!(LogLevel::Debug, "Switch to new kernel stack...");
-    update_kernel_sp();
+    mem_update_kernel_sp();
     // Allow empty loop because it will never enter, just to make the fn never return without
     // warning
     #[allow(clippy::empty_loop)]

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -19,12 +19,13 @@ Tests files:
 
 mod kernel;
 
-use core::{arch::asm, mem};
+use core::mem;
 
 use kernel::{__kernel_end, __kernel_start, KernelStack};
 
 use crate::{
-    arch, config::KERNEL_STACK_SIZE, log, logs::LogLevel, platform::mem::platform_init_mem,
+    arch::mem::update_kernel_sp, config::KERNEL_STACK_SIZE, log, logs::LogLevel,
+    platform::mem::platform_init_mem,
 };
 
 pub struct Memory {
@@ -137,17 +138,16 @@ pub fn memory_init() {
     }
 }
 
-#[unsafe(no_mangle)]
-pub fn update_kernel_sp() {
-    unsafe { asm!("mv a0, {}", in(reg) MEMORY.kernel_stack.top) };
-    unsafe { arch::asm::set_kernel_sp() };
-}
-
 pub fn mem_kernel_stack_info<'a>() -> &'a KernelStack {
     #[allow(static_mut_refs)]
     unsafe {
         &MEMORY.kernel_stack
     }
+}
+
+pub fn mem_update_kernel_sp() {
+    let sp: usize = unsafe { MEMORY.kernel_stack.top };
+    update_kernel_sp(sp);
 }
 
 /// Return the hi and lo address of the RAM


### PR DESCRIPTION
This pull request refactors how the kernel stack pointer is updated in the RISC-V32 architecture. The main change is to make the stack pointer update function accept an explicit stack pointer argument, improving clarity and modularity. The update also reorganizes related code into more appropriate modules.

**Refactoring and modularization of kernel stack pointer update:**

* Added a new `update_kernel_sp(sp: usize)` function to `src/arch/riscv32/mem.rs`, which sets the kernel stack pointer using an explicit argument.
* Replaced the old `update_kernel_sp()` function in `src/mem/mod.rs` with a new `mem_update_kernel_sp()` function, which retrieves the stack pointer from memory and calls the new `update_kernel_sp(sp)` function.
* Updated boot process in `src/boot.rs` to use `mem_update_kernel_sp()` instead of the previous `update_kernel_sp()`. [[1]](diffhunk://#diff-d912ff9d8ba1a195bf14282d38de1732d78a6cafdb35140bd3510edf01ccc8bfL10-R10) [[2]](diffhunk://#diff-d912ff9d8ba1a195bf14282d38de1732d78a6cafdb35140bd3510edf01ccc8bfL37-R37)
* Moved the new memory-related code into the `arch::riscv32::mem` module and updated imports accordingly. [[1]](diffhunk://#diff-75862bbae7a91118ce4a1ec63fe1f7c847eed549b290eb2ca3670d0bc636f51bR2) [[2]](diffhunk://#diff-8cc43508192c38927be51dc8cf7964f695ee695f5c843d54bad10dbeec65187bL22-R28)

This pull-request improve the codebase by avoiding that the kernel function use arch specific asm, leave the asm in the arch specific module.